### PR TITLE
fixbug: body插件未根据Content-Type来判断是否应该处理http body

### DIFF
--- a/plugs/body/body_plug.go
+++ b/plugs/body/body_plug.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/AlexanderChen1989/xrest"
 
@@ -63,7 +64,17 @@ func (bp *body) Plug(h xrest.Handler) xrest.Handler {
 	return bp
 }
 
+const (
+	jsonMediaType = "application/json"
+)
+
 func (bp *body) ServeHTTP(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	mediaType := r.Header.Get("Content-Type")
+	if len(mediaType) > 0 && !strings.HasPrefix(mediaType, jsonMediaType) {
+		bp.next.ServeHTTP(ctx, w, r)
+		return
+	}
+
 	if _, ok := FetchBody(ctx); !ok {
 		buf := getBuffer()
 		defer buf.free()


### PR DESCRIPTION
当http request的`Content-Type`为非`application/json`时(如文件上传`multipart/form-data`)，那么body插件就会将http body内容读入context，等到真正的处理逻辑时就无法从http body中读取到数据了，而是`EOF`。
